### PR TITLE
style: fix some typos in documentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 - [Pradish Bijukchhe](https://github.com/pradishb)
 - [Peter Hoburg](https://github.com/peterHoburg)
 - [Christian Assing](https://github.com/chassing)
+- [Alexander Gubin](https://github.com/alxgu)

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -80,7 +80,7 @@ Copy and paste the correct version contents from CHANGELOG.md.
 
 Mark as the latest release.
 
-## Pubish documentation
+## Publish documentation
 
 Nice and easy
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ client = clientele_api.APIClient(base_url="http://localhost:8000")
 
 
 @client.post("/books")
-def create_book(data: CreateBookRequest, result: CreateBookReponse) -> CreateBookResponse:
+def create_book(data: CreateBookRequest, result: CreateBookResponse) -> CreateBookResponse:
     return result
 ```
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,7 +66,7 @@ async for event in await stream_events():
 ## 1.4.0
 
 - You can now pass `TypedDict` instances for the `data` parameter on `post`, `put`, `patch` and `delete` methods.
-- Decoratored fucntions now accept a `response_parser` callback that will handle the response parsing. Use this to customise the `result` value that is sent back to the function.
+- Decorated functions now accept a `response_parser` callback that will handle the response parsing. Use this to customise the `result` value that is sent back to the function.
 
 ## 1.3.0
 

--- a/docs/api-async.md
+++ b/docs/api-async.md
@@ -9,15 +9,15 @@ They can even be mixed in together if you prefer.
 ```python
 from clientele import api as clientele_api
 from .my_config import Config
-from .my_models import BookResponse, CreateBookReponse, CreateBookRequest
+from .my_models import BookResponse, CreateBookResponse, CreateBookRequest
 
 client = clientele_api.APIClient(config=Config())
 
 @client.post("/books")
 def create_user(
-    data: CreateBookReponse,
-    result: CreateBookReponse,
-) -> CreateBookReponse:
+    data: CreateBookResponse,
+    result: CreateBookResponse,
+) -> CreateBookResponse:
     return result
 
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -37,7 +37,7 @@ def get_pokemon_info(pokemon_name: str, result: PokemonInfo) -> PokemonInfo:
 ```
 
 - Use Pydantic `BaseModel` to return only the data you want in the `result` parameter.
-- Pydantic's `model_validate` will be ran against the `reponse.json`.
+- Pydantic's `model_validate` will be ran against the `response.json`.
 - Only values explicitly declared in the `BaseModel` will be returned.
 
 ## Return specific data after result
@@ -152,7 +152,7 @@ def get_pokemon_info(pokemon_name: str, result: dict, response: httpx.Response) 
 
 ```
 
-- Pass the `response` parameter to the decorated function to recive the `httpx.Response` object.
+- Pass the `response` parameter to the decorated function to receive the `httpx.Response` object.
 
 ## Control response parsing
 
@@ -178,7 +178,7 @@ def get_pokemon_info(pokemon_name: str, result: dict) -> str:
 ```
 
 - Pass a callable to the `response_parser` parameter to control how http responses are parsed.
-- Clientele will no longer handle any data validation for you, but you have compelete control.
+- Clientele will no longer handle any data validation for you, but you have complete control.
 - The return type of this callback must match the type of the `result` parameter.
 
 ### Using strong types
@@ -244,12 +244,12 @@ from clientele import api
 client = api.APIClient(base_url="https://pokeapi.co/api/v2")
 
 
-class OnlyErroResult(BaseModel):
+class OnlyErrorResult(BaseModel):
     name: str
 
 
-@client.get("/pokemon/{pokemon_name}", response_map={500: OnlyErroResult})
-def get_pokemon_info(pokemon_name: str, result: OnlyErroResult) -> str:
+@client.get("/pokemon/{pokemon_name}", response_map={500: OnlyErrorResult})
+def get_pokemon_info(pokemon_name: str, result: OnlyErrorResult) -> str:
     return result.name
 
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -180,7 +180,7 @@ Despite a well-defined [specification](https://www.openapis.org/), we've discove
 **Recommendation:**
 
 - Report issues with specific schemas to help us improve
-- For FastAPI, DRF, and Django Ninja, compatibility is guarenteed
+- For FastAPI, DRF, and Django Ninja, compatibility is guaranteed
 
 ### OpenAPI 3.1 Caveats
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -16,7 +16,7 @@ Every few years I check the HTTP API landscape to see what has changed, and what
 
 A big part of this research is seeing how far [OpenAPI client generators](https://www.openapis.org/) have come.  
 
-Despite the heavy adoption of OpenAPI _schema_ generators, the "last mile" (i.e. - generating, and using, a client library) still has a experience nowhere near the maturity as the schema generator landscape. The great thing about schema generators these days is they are seemlessly blended in - most API server frameworks, especially in the Python landscape, generate schemas as standard.
+Despite the heavy adoption of OpenAPI _schema_ generators, the "last mile" (i.e. - generating, and using, a client library) still has a experience nowhere near the maturity as the schema generator landscape. The great thing about schema generators these days is they are seamlessly blended in - most API server frameworks, especially in the Python landscape, generate schemas as standard.
 
 But my experience with most _client_ generators always falls into one of these buckets:
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -1,6 +1,6 @@
 # 🚨 Exception Handling
 
-Clientele wll handle unexpected API responses by raising an `APIException`.
+Clientele will handle unexpected API responses by raising an `APIException`.
 
 ## When APIException is Raised
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ client = clientele_api.APIClient(base_url="http://localhost:8000")
 
 
 @client.post("/books")
-def create_book(data: CreateBookRequest, result: CreateBookReponse) -> CreateBookResponse:
+def create_book(data: CreateBookRequest, result: CreateBookResponse) -> CreateBookResponse:
     return result
 ```
 


### PR DESCRIPTION
# Change summary

Fix some typos in the documentation

## Related issue(s)

## Pull request tasks

The following have been completed for this task:

- [ ] **Code changes**
- [ ] **Tests written**
- [x] **Documentation changes for new or changed features**
- [ ] **Pre-review preparation**
  - [x] `make test`
  - [ ] `make format`
  - [ ] `make ty`
  - [ ] `make generate-test-clients`
    - [ ] Test clients have changed because a new feature was introduced
    - [ ] Test clients remain the same
- [ ] Changelog updated
- [x] Contributors updated


## Other information

I'm getting an error when running `make test` in my branch and even in the main branch :/

`tests/test_cli.py::test_load_openapi_spec_from_url[application/x-yaml-dump] FAILED`
