### PR TITLE
Fix OpenAPI `default`, `const`, and `$ref` parameter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change log
 
-## 2.1.0 UNRELEASED
+## 2.2.0
+
+- Support OpenAPI `default` and `const` in schema generation ([#247](https://github.com/phalt/clientele/pull/247)).
+- Fix `$ref` parameter types and double-nullable handling in client generation ([#247](https://github.com/phalt/clientele/pull/247)).
+
+## 2.1.0
 
 - Introduce `RequestsHTTPBackend` for making HTTP requests using the `requests` library.
   - This backend implements synchronous HTTP requests only.

--- a/clientele/generators/base_clients.py
+++ b/clientele/generators/base_clients.py
@@ -143,16 +143,20 @@ class BaseClientsGenerator:
             required = param.get("required", False) or in_ != "query"
             if in_ == "query":
                 # URL query string values
+                param_type = utils.resolve_forward_refs_for_client(utils.get_type(param["schema"]))
                 if required:
-                    query_args[clean_key] = utils.get_type(param["schema"])
+                    query_args[clean_key] = param_type
                 else:
-                    query_args[clean_key] = f"typing.Optional[{utils.get_type(param['schema'])}]"
+                    param_type = utils.strip_none_from_type(param_type)
+                    query_args[clean_key] = f"typing.Optional[{param_type}]"
             elif in_ == "path":
                 # Function arguments
+                param_type = utils.resolve_forward_refs_for_client(utils.get_type(param["schema"]))
                 if required:
-                    path_args[clean_key] = utils.get_type(param["schema"])
+                    path_args[clean_key] = param_type
                 else:
-                    path_args[clean_key] = f"typing.Optional[{utils.get_type(param['schema'])}]"
+                    param_type = utils.strip_none_from_type(param_type)
+                    path_args[clean_key] = f"typing.Optional[{param_type}]"
             elif in_ == "header":
                 # Header object arguments
                 headers_args[param["name"]] = utils.get_type(param["schema"])

--- a/clientele/generators/cicerone_compat.py
+++ b/clientele/generators/cicerone_compat.py
@@ -191,6 +191,10 @@ def schema_to_dict(schema) -> dict:
     if hasattr(schema, "__pydantic_extra__") and schema.__pydantic_extra__ and "enum" in schema.__pydantic_extra__:
         result["enum"] = schema.__pydantic_extra__["enum"]
 
+    # Handle default - it's in the extra fields; use "in" check since defaults can be falsy
+    if hasattr(schema, "__pydantic_extra__") and schema.__pydantic_extra__ and "default" in schema.__pydantic_extra__:
+        result["default"] = schema.__pydantic_extra__["default"]
+
     # Handle properties
     if hasattr(schema, "properties") and schema.properties:
         result["properties"] = {k: schema_to_dict(v) for k, v in schema.properties.items()}

--- a/clientele/generators/cicerone_compat.py
+++ b/clientele/generators/cicerone_compat.py
@@ -195,6 +195,10 @@ def schema_to_dict(schema) -> dict:
     if hasattr(schema, "__pydantic_extra__") and schema.__pydantic_extra__ and "default" in schema.__pydantic_extra__:
         result["default"] = schema.__pydantic_extra__["default"]
 
+    # Handle const - it's in the extra fields
+    if hasattr(schema, "__pydantic_extra__") and schema.__pydantic_extra__ and "const" in schema.__pydantic_extra__:
+        result["const"] = schema.__pydantic_extra__["const"]
+
     # Handle properties
     if hasattr(schema, "properties") and schema.properties:
         result["properties"] = {k: schema_to_dict(v) for k, v in schema.properties.items()}

--- a/clientele/generators/shared/generators/schemas.py
+++ b/clientele/generators/shared/generators/schemas.py
@@ -54,12 +54,19 @@ class SchemasGenerator:
             sanitized_arg = utils.snake_case_prop(arg)
             arg_type = utils.get_type(arg_details)
             is_optional = required and arg not in required
+            has_default = "default" in arg_details
 
             needs_alias = sanitized_arg != arg
             if needs_alias:
                 has_aliases = True
 
-            if is_optional and not arg_type.startswith("typing.Optional["):
+            if has_default:
+                py_default = repr(arg_details["default"])
+                if needs_alias:
+                    type_string = f'{arg_type} = pydantic.Field(default={py_default}, alias="{arg}")'
+                else:
+                    type_string = f"{arg_type} = {py_default}"
+            elif is_optional and not arg_type.startswith("typing.Optional["):
                 if needs_alias:
                     type_string = f'typing.Optional[{arg_type}] = pydantic.Field(default=None, alias="{arg}")'
                 else:

--- a/clientele/generators/shared/utils.py
+++ b/clientele/generators/shared/utils.py
@@ -280,8 +280,21 @@ def remove_forward_ref_quotes(type_string: str) -> str:
     This is used for type aliases where forward references are not needed
     because all types are defined in the same module and model_rebuild() is called.
     """
-    import re
-
-    # Replace quoted strings within type annotations
-    # Pattern: matches quoted strings that are type names (alphanumeric + underscore)
     return re.sub(r'"([A-Za-z_][A-Za-z0-9_]*)"', r"\1", type_string)
+
+
+def resolve_forward_refs_for_client(type_string: str) -> str:
+    """Replace forward references with schemas module references for client.py context."""
+    return re.sub(r'"([A-Za-z_][A-Za-z0-9_]*)"', r"schemas.\1", type_string)
+
+
+def strip_none_from_type(type_string: str) -> str:
+    """Strip None/Optional wrapping so the caller can re-wrap without duplication."""
+    if type_string.startswith("typing.Optional[") and type_string.endswith("]"):
+        return type_string[len("typing.Optional[") : -1]
+    m = re.match(r"^typing\.Union\[(.+),\s*None\]$", type_string)
+    if m:
+        return m.group(1)
+    if type_string.endswith(" | None"):
+        return type_string[: -len(" | None")]
+    return type_string

--- a/clientele/generators/shared/utils.py
+++ b/clientele/generators/shared/utils.py
@@ -97,6 +97,9 @@ def get_func_name(operation: dict, path: str) -> str:
 
 
 def get_type(t):
+    if "const" in t:
+        return f"typing.Literal[{repr(t['const'])}]"
+
     t_type = t.get("type")
     t_format = t.get("format")
     t_nullable = t.get("nullable", False)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change log
 
-## 2.1.0 UNRELEASED
+## 2.2.0
+
+- Support OpenAPI `default` and `const` in schema generation ([#247](https://github.com/phalt/clientele/pull/247)).
+- Fix `$ref` parameter types and double-nullable handling in client generation ([#247](https://github.com/phalt/clientele/pull/247)).
+
+## 2.1.0
 
 - Introduce `RequestsHTTPBackend` for making HTTP requests using the `requests` library.
   - This backend implements synchronous HTTP requests only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clientele"
-version = "2.1.0"
+version = "2.2.0"
 description = "Clientele is a different way to build Python API Clients"
 authors = [{ name = "Paul Hallett", email = "paulandrewhallett@gmail.com" }]
 license = { text = "MIT" }

--- a/tests/generators/shared/test_utils_coverage.py
+++ b/tests/generators/shared/test_utils_coverage.py
@@ -139,3 +139,25 @@ def test_get_schema_from_ref_basic():
             # Should return a dict
             assert result is not None
             assert isinstance(result, dict)
+
+
+def test_resolve_forward_refs_for_client():
+    """Test that forward references are replaced with schemas module references."""
+    assert utils.resolve_forward_refs_for_client('"ActionStatus"') == "schemas.ActionStatus"
+    assert (
+        utils.resolve_forward_refs_for_client('typing.Union["ActionStatus", None]')
+        == "typing.Union[schemas.ActionStatus, None]"
+    )
+    assert utils.resolve_forward_refs_for_client('list["MyModel"]') == "list[schemas.MyModel]"
+    assert utils.resolve_forward_refs_for_client("str") == "str"
+    assert utils.resolve_forward_refs_for_client("int") == "int"
+
+
+def test_strip_none_from_type():
+    """Test stripping None/Optional wrapping from type strings."""
+    assert utils.strip_none_from_type("typing.Optional[str]") == "str"
+    assert utils.strip_none_from_type("typing.Union[schemas.ActionStatus, None]") == "schemas.ActionStatus"
+    assert utils.strip_none_from_type("schemas.ActionStatus | None") == "schemas.ActionStatus"
+    assert utils.strip_none_from_type("str") == "str"
+    assert utils.strip_none_from_type("typing.Optional[list[str]]") == "list[str]"
+    assert utils.strip_none_from_type("typing.Union[dict[str, int], None]") == "dict[str, int]"

--- a/tests/generators/test_base_and_basic_coverage.py
+++ b/tests/generators/test_base_and_basic_coverage.py
@@ -82,6 +82,48 @@ def test_clients_generator_handles_optional_path_parameters():
         assert "Optional" in result.query_args["filter"]
 
 
+def test_clients_generator_resolves_schema_refs_in_parameters():
+    """Test that $ref schema types in parameters use schemas.X prefix."""
+    spec = load_spec("simple.json")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "test_client"
+        output_dir.mkdir(parents=True)
+
+        from clientele.generators.api import writer as api_writer
+        from clientele.generators.shared.generators.schemas import SchemasGenerator
+
+        schemas_gen = SchemasGenerator(spec=spec, output_dir=str(output_dir), writer=api_writer)
+
+        generator = api_clients.ClientsGenerator(
+            spec=spec,
+            output_dir=str(output_dir),
+            schemas_generator=schemas_gen,
+            asyncio=False,
+        )
+
+        parameters = [
+            {
+                "name": "status",
+                "in": "query",
+                "required": False,
+                "schema": {
+                    "anyOf": [
+                        {"$ref": "#/components/schemas/ActionStatus"},
+                        {"type": "null"},
+                    ],
+                },
+            }
+        ]
+
+        result = generator.generate_parameters(parameters, [])
+
+        assert "status" in result.query_args
+        param_type = result.query_args["status"]
+        assert "schemas.ActionStatus" in param_type
+        assert param_type.count("None") <= 1
+
+
 def test_clients_generator_handles_multiple_input_classes():
     """Test that clients generator handles multiple input classes."""
     spec = load_spec("simple.json")

--- a/tests/generators/test_schemas_coverage.py
+++ b/tests/generators/test_schemas_coverage.py
@@ -167,3 +167,67 @@ def test_generate_class_properties_no_required_array_with_defaults():
         assert "count: int = 0\n" in result
         assert "enabled: bool = True\n" in result
         assert "typing.Optional" not in result
+
+
+def test_generate_class_properties_with_const():
+    """Test that const values generate typing.Literal types."""
+    spec = load_spec("simple.json")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "test_schemas"
+        output_dir.mkdir(parents=True)
+
+        generator = _make_generator(spec, output_dir)
+
+        properties = {
+            "action": {"type": "string", "const": "create"},
+            "name": {"type": "string"},
+        }
+
+        result = generator.generate_class_properties(properties, required=["action", "name"])
+
+        assert "action: typing.Literal['create']\n" in result
+        assert "name: str\n" in result
+
+
+def test_generate_class_properties_const_with_default():
+    """Test that const + default generates Literal type with default value."""
+    spec = load_spec("simple.json")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "test_schemas"
+        output_dir.mkdir(parents=True)
+
+        generator = _make_generator(spec, output_dir)
+
+        properties = {
+            "action": {"type": "string", "const": "add-user", "default": "add-user"},
+            "message": {"type": "string"},
+        }
+
+        result = generator.generate_class_properties(properties, required=["message"])
+
+        assert "action: typing.Literal['add-user'] = 'add-user'\n" in result
+        assert "message: str\n" in result
+
+
+def test_generate_class_properties_const_with_alias():
+    """Test that const field with alias uses pydantic.Field."""
+    spec = load_spec("simple.json")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "test_schemas"
+        output_dir.mkdir(parents=True)
+
+        generator = _make_generator(spec, output_dir)
+
+        properties = {
+            "action-type": {"type": "string", "const": "delete", "default": "delete"},
+        }
+
+        result = generator.generate_class_properties(properties, required=[])
+
+        assert (
+            "action_type: typing.Literal['delete'] = pydantic.Field(default='delete', alias=\"action-type\")" in result
+        )
+        assert "model_config = pydantic.ConfigDict(populate_by_name=True)" in result

--- a/tests/generators/test_schemas_coverage.py
+++ b/tests/generators/test_schemas_coverage.py
@@ -94,3 +94,76 @@ def test_schemas_generator_handles_allof_with_object_properties():
         generator.make_schema_class("TestAllOfObject", schema_with_allof_object)
 
         assert "TestAllOfObject" in generator.schemas
+
+
+def test_generate_class_properties_with_defaults():
+    """Test that explicit default values from OpenAPI specs are rendered."""
+    spec = load_spec("simple.json")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "test_schemas"
+        output_dir.mkdir(parents=True)
+
+        generator = _make_generator(spec, output_dir)
+
+        properties = {
+            "name": {"type": "string"},
+            "tags": {"type": "array", "items": {"type": "string"}, "default": []},
+            "count": {"type": "integer", "default": 0},
+            "enabled": {"type": "boolean", "default": False},
+            "label": {"type": "string", "default": ""},
+            "description": {"type": "string", "default": None},
+        }
+
+        result = generator.generate_class_properties(properties, required=["name"])
+
+        assert "name: str\n" in result
+        assert "tags: list[str] = []\n" in result
+        assert "count: int = 0\n" in result
+        assert "enabled: bool = False\n" in result
+        assert "label: str = ''\n" in result
+        assert "description: str = None\n" in result
+
+
+def test_generate_class_properties_default_with_alias():
+    """Test that fields with both alias and default use pydantic.Field."""
+    spec = load_spec("simple.json")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "test_schemas"
+        output_dir.mkdir(parents=True)
+
+        generator = _make_generator(spec, output_dir)
+
+        properties = {
+            "my-field": {"type": "integer", "default": 42},
+        }
+
+        result = generator.generate_class_properties(properties, required=[])
+
+        assert 'my_field: int = pydantic.Field(default=42, alias="my-field")' in result
+        assert "model_config = pydantic.ConfigDict(populate_by_name=True)" in result
+
+
+def test_generate_class_properties_no_required_array_with_defaults():
+    """Test schema with no required array where all fields have defaults."""
+    spec = load_spec("simple.json")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "test_schemas"
+        output_dir.mkdir(parents=True)
+
+        generator = _make_generator(spec, output_dir)
+
+        properties = {
+            "tags": {"type": "array", "items": {"type": "string"}, "default": []},
+            "count": {"type": "integer", "default": 0},
+            "enabled": {"type": "boolean", "default": True},
+        }
+
+        result = generator.generate_class_properties(properties, required=None)
+
+        assert "tags: list[str] = []\n" in result
+        assert "count: int = 0\n" in result
+        assert "enabled: bool = True\n" in result
+        assert "typing.Optional" not in result

--- a/uv.lock
+++ b/uv.lock
@@ -391,7 +391,7 @@ wheels = [
 
 [[package]]
 name = "clientele"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx2" },


### PR DESCRIPTION
## Summary

- **`default` support**: `generate_class_properties` now reads `"default"` from OpenAPI property definitions and renders the value as a Python literal via `repr()`. Fields with both a default and an alias use `pydantic.Field(default=..., alias="...")`. Uses `"default" in arg_details` (not truthiness) so falsy defaults like `[]`, `0`, `False`, `""`, and `null` are handled correctly.
- **`const` support**: `get_type` now checks for `"const"` and generates `typing.Literal[<value>]`. This is required for Pydantic discriminated unions to work — without `Literal`, Pydantic raises `PydanticUserError: Model needs field to be of type Literal`.
- **`$ref` in parameters**: Parameters referencing schemas via `$ref` (e.g. enums like `ActionStatus`) now resolve to `schemas.X` in `client.py` instead of bare forward references with no import.
- **Double-nullable fix**: `anyOf: [$ref, {type: null}]` parameters no longer produce `X | None | None` — existing nullability is detected and not duplicated.
- **`schema_to_dict` compat layer**: Extracts both `"default"` and `"const"` from cicerone's `__pydantic_extra__`, which were previously silently dropped during spec parsing.

**Before**:
```python
# schemas.py — defaults ignored, const ignored
class Config(pydantic.BaseModel):
    tags: list[str]       # spec says default: []
    count: int            # spec says default: 0

class NotificationAddUser(pydantic.BaseModel):
    action: str           # spec says const: "add-user" — breaks discriminated unions
    message: str

# client.py — broken import, double None
def action_list(
    status: ActionStatus | None | None = None,  # NameError: ActionStatus not imported
) -> schemas.ResponseActionList: ...
```

**After**:
```python
# schemas.py
class Config(pydantic.BaseModel):
    tags: list[str] = []
    count: int = 0

class NotificationAddUser(pydantic.BaseModel):
    action: typing.Literal["add-user"] = "add-user"  # discriminated unions work
    message: str

# client.py
def action_list(
    status: typing.Optional[schemas.ActionStatus] = None,  # correct import, single None
) -> schemas.ResponseActionList: ...
```

## Test plan

- [x] `test_generate_class_properties_with_defaults` — list `[]`, int `0`, bool `False`, string `""`, null defaults
- [x] `test_generate_class_properties_default_with_alias` — field with alias + default uses `pydantic.Field`
- [x] `test_generate_class_properties_no_required_array_with_defaults` — schema with no `required` array, all fields have explicit defaults
- [x] `test_generate_class_properties_with_const` — const generates `typing.Literal`
- [x] `test_generate_class_properties_const_with_default` — const + default generates `Literal` type with default value
- [x] `test_generate_class_properties_const_with_alias` — const + alias uses `pydantic.Field`
- [x] `test_resolve_forward_refs_for_client` — forward refs replaced with `schemas.X`
- [x] `test_strip_none_from_type` — handles Optional, Union with None, pipe None, plain types
- [x] `test_clients_generator_resolves_schema_refs_in_parameters` — `anyOf: [$ref, null]` produces `typing.Optional[schemas.X]` without double None
- [x] End-to-end: specs with discriminator + enum ref parameters generate correct, loadable code
- [x] Full test suite passes (559/559, excluding pre-existing aiohttp failures)