### PR TITLE
Fix array response RootModel and config BASE_URL example (issue #248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Support OpenAPI `default` and `const` in schema generation ([#247](https://github.com/phalt/clientele/pull/247)).
 - Fix `$ref` parameter types and double-nullable handling in client generation ([#247](https://github.com/phalt/clientele/pull/247)).
+- Fix array response schemas being emitted as plain type aliases (`list[...]`) which pydantic rejects in `response_map` — they are now emitted as `pydantic.RootModel` subclasses ([#248](https://github.com/phalt/clientele/issues/248)).
+- Fix generated `config.py` documenting `API_BASE_URL` as the environment variable name when pydantic-settings reads `BASE_URL` — the example now uses the correct name ([#248](https://github.com/phalt/clientele/issues/248)).
 
 ## 2.1.0
 

--- a/clientele/generators/api/templates/config_py.jinja2
+++ b/clientele/generators/api/templates/config_py.jinja2
@@ -19,14 +19,12 @@ class Config(clientele_api.BaseConfig):
 
     Example:
         # From environment variables
-        export API_BASE_URL="https://api.example.com"
-        export BEARER_TOKEN="my-secret-token"
+        export BASE_URL="https://api.example.com"
         config = Config()
 
         # Direct instantiation
         config = Config(
-            api_base_url="https://api.example.com",
-            bearer_token="my-token",
+            base_url="https://api.example.com",
             timeout=10.0
         )
     """

--- a/clientele/generators/api/templates/schema_root_model.jinja2
+++ b/clientele/generators/api/templates/schema_root_model.jinja2
@@ -1,0 +1,4 @@
+
+
+class {{class_name}}(pydantic.RootModel[{{inner_type}}]):
+    pass

--- a/clientele/generators/shared/generators/schemas.py
+++ b/clientele/generators/shared/generators/schemas.py
@@ -135,10 +135,14 @@ class SchemasGenerator:
             return
 
         if schema.get("type") == "array":
+            # Emit a pydantic.RootModel subclass rather than a plain type alias.
+            # list[...] is a GenericAlias, not a type, so pydantic rejects it
+            # when it appears in response_map: dict[int, type[Any]].  A RootModel
+            # subclass is a proper class and satisfies that constraint.
             array_type = utils.get_type(schema)
             array_type = utils.remove_forward_ref_quotes(array_type)
-            template = self.writer.templates.get_template("schema_type_alias.jinja2")
-            content = template.render(class_name=schema_key, union_type=array_type)
+            template = self.writer.templates.get_template("schema_root_model.jinja2")
+            content = template.render(class_name=schema_key, inner_type=array_type)
             self.writer.write_to_schemas(content, output_dir=self.output_dir)
             self.schemas[schema_key] = ""
             return

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Support OpenAPI `default` and `const` in schema generation ([#247](https://github.com/phalt/clientele/pull/247)).
 - Fix `$ref` parameter types and double-nullable handling in client generation ([#247](https://github.com/phalt/clientele/pull/247)).
+- Fix array response schemas being emitted as plain type aliases (`list[...]`) which pydantic rejects in `response_map` — they are now emitted as `pydantic.RootModel` subclasses ([#248](https://github.com/phalt/clientele/issues/248)).
+- Fix generated `config.py` documenting `API_BASE_URL` as the environment variable name when pydantic-settings reads `BASE_URL` — the example now uses the correct name ([#248](https://github.com/phalt/clientele/issues/248)).
 
 ## 2.1.0
 

--- a/example_openapi_specs/issue_248.json
+++ b/example_openapi_specs/issue_248.json
@@ -1,0 +1,85 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Issue 248 Reproduction",
+    "description": "Reproduces Bug 2 (array RootModel) and Bug 3 (config env var name) from issue #248",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {"url": "https://api.example.com"}
+  ],
+  "paths": {
+    "/faces": {
+      "get": {
+        "summary": "Get Faces",
+        "operationId": "get_faces",
+        "parameters": [
+          {
+            "name": "faces_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {"$ref": "#/components/schemas/FaceTypeEnum"}
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/FaceItem"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/upload-faces": {
+      "post": {
+        "summary": "Upload Faces",
+        "operationId": "upload_faces",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {"$ref": "#/components/schemas/FaceItem"}
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {"$ref": "#/components/schemas/FaceItem"}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FaceTypeEnum": {
+        "type": "string",
+        "enum": ["FRONT", "SIDE", "BACK"],
+        "title": "FaceTypeEnum"
+      },
+      "FaceItem": {
+        "type": "object",
+        "title": "FaceItem",
+        "properties": {
+          "id": {"type": "integer"},
+          "name": {"type": "string"}
+        },
+        "required": ["id", "name"]
+      }
+    }
+  }
+}

--- a/tests/test_complex_schemas.py
+++ b/tests/test_complex_schemas.py
@@ -295,8 +295,8 @@ class TestArrayResponses:
     """Test top-level array response handling."""
 
     @pytest.mark.parametrize("client_generator", [APIGenerator])
-    def test_array_response_generates_type_alias(self, tmp_path, client_generator):
-        """Test that top-level array responses generate type aliases, not empty classes."""
+    def test_array_response_generates_root_model(self, tmp_path, client_generator):
+        """Top-level array responses must emit a pydantic.RootModel subclass, not a plain type alias."""
         spec = load_spec("complex_schemas.json")
         spec_path = get_spec_path("complex_schemas.json")
         generator = client_generator(
@@ -312,7 +312,8 @@ class TestArrayResponses:
         schemas_file = tmp_path / "schemas.py"
         schemas_content = schemas_file.read_text()
 
-        assert "ResponseListUsers = list[User]" in schemas_content
+        assert "class ResponseListUsers(pydantic.RootModel[list[User]]):" in schemas_content
+        assert "ResponseListUsers = list[User]" not in schemas_content
         assert "class ResponseListUsers(pydantic.BaseModel):" not in schemas_content
         assert "class User(pydantic.BaseModel):" in schemas_content
         assert "id: int" in schemas_content
@@ -320,8 +321,8 @@ class TestArrayResponses:
         assert "email: str" in schemas_content
 
     @pytest.mark.parametrize("client_generator", [APIGenerator])
-    def test_array_response_without_title_generates_type_alias(self, tmp_path, client_generator):
-        """Test that array responses without title also generate type aliases correctly."""
+    def test_array_response_without_title_generates_root_model(self, tmp_path, client_generator):
+        """Array responses without a title must also become RootModel subclasses."""
         spec = load_spec("complex_schemas.json")
         spec_path = get_spec_path("complex_schemas.json")
         generator = client_generator(
@@ -337,8 +338,10 @@ class TestArrayResponses:
         schemas_file = tmp_path / "schemas.py"
         schemas_content = schemas_file.read_text()
 
-        assert "ListUsersNoTitleListUsersNoTitleGet200Response = list[User]" in schemas_content
-        assert "class ListUsersNoTitleListUsersNoTitleGet200Response(pydantic.BaseModel):" not in schemas_content
+        assert (
+            "class ListUsersNoTitleListUsersNoTitleGet200Response(pydantic.RootModel[list[User]]):" in schemas_content
+        )
+        assert "ListUsersNoTitleListUsersNoTitleGet200Response = list[User]" not in schemas_content
         assert "test: list[" not in schemas_content
 
 

--- a/tests/test_issue_248.py
+++ b/tests/test_issue_248.py
@@ -70,7 +70,7 @@ class TestBug2ArrayResponseRootModel:
         )
 
     def test_array_response_rootmodel_is_valid_type(self, tmp_path):
-        """The generated array response class must satisfy isinstance(cls, type) so pydantic accepts it in response_map."""
+        """Generated array response class must satisfy isinstance(cls, type) so pydantic accepts it in response_map."""
         generator = _make_generator(tmp_path)
         generator.generate()
 

--- a/tests/test_issue_248.py
+++ b/tests/test_issue_248.py
@@ -1,0 +1,126 @@
+"""
+Regression tests for GitHub issue #248.
+
+Bug 1 (enum forward refs in client.py) was fixed by PR #247.
+
+Two remaining bugs:
+  Bug 2 - Array response schemas are emitted as plain type aliases
+           (list[...]) instead of pydantic.RootModel subclasses.
+           list[...] is a GenericAlias, not a type, so pydantic rejects
+           it in response_map: dict[int, type[Any]].
+  Bug 3 - The generated config.py docstring example says API_BASE_URL
+           but pydantic-settings reads the field as BASE_URL (field name
+           is base_url). The wrong name is silently ignored and the
+           client falls back to http://localhost.
+"""
+
+import sys
+from contextlib import contextmanager
+
+from clientele.generators.api.generator import APIGenerator
+from tests.generators.integration_utils import get_spec_path, load_spec
+
+
+@contextmanager
+def _import_generated_schemas(tmp_path):
+    sys.path.insert(0, str(tmp_path))
+    try:
+        yield
+    finally:
+        sys.path.remove(str(tmp_path))
+        for mod in list(sys.modules):
+            if mod in ("schemas", "client", "config"):
+                del sys.modules[mod]
+
+
+def _make_generator(tmp_path, spec_filename="issue_248.json"):
+    spec = load_spec(spec_filename)
+    spec_path = get_spec_path(spec_filename)
+    return APIGenerator(
+        spec=spec,
+        output_dir=str(tmp_path),
+        asyncio=False,
+        regen=True,
+        url=None,
+        file=str(spec_path),
+    )
+
+
+class TestBug2ArrayResponseRootModel:
+    """
+    Bug 2: array response schemas are emitted as plain type aliases
+    (e.g. UploadFaces200Response = list[FaceItem]).  A GenericAlias is
+    not a type, so pydantic rejects it in response_map: dict[int, type[Any]].
+    The fix is to emit a pydantic.RootModel subclass instead.
+    """
+
+    def test_array_response_schema_is_rootmodel_not_type_alias(self, tmp_path):
+        """schemas.py must emit a pydantic.RootModel subclass for array responses, not a bare type alias."""
+        generator = _make_generator(tmp_path)
+        generator.generate()
+
+        schemas_content = (tmp_path / "schemas.py").read_text()
+
+        assert "UploadFaces200Response = list[" not in schemas_content, (
+            "schemas.py emitted a plain type alias for an array response; "
+            "it should emit a pydantic.RootModel subclass instead"
+        )
+        assert "class UploadFaces200Response(pydantic.RootModel[list[FaceItem]]):" in schemas_content, (
+            "schemas.py should emit a pydantic.RootModel subclass for array responses"
+        )
+
+    def test_array_response_rootmodel_is_valid_type(self, tmp_path):
+        """The generated array response class must satisfy isinstance(cls, type) so pydantic accepts it in response_map."""
+        generator = _make_generator(tmp_path)
+        generator.generate()
+
+        with _import_generated_schemas(tmp_path):
+            import schemas  # type: ignore
+
+            cls = schemas.UploadFaces200Response
+            assert isinstance(cls, type), f"{cls!r} is not a type; pydantic would reject it in response_map"
+
+    def test_array_response_rootmodel_instantiation(self, tmp_path):
+        """The generated RootModel subclass must be instantiable with a list."""
+        generator = _make_generator(tmp_path)
+        generator.generate()
+
+        with _import_generated_schemas(tmp_path):
+            import schemas  # type: ignore
+
+            instance = schemas.UploadFaces200Response(root=[{"id": 1, "name": "Alice"}])
+            assert len(instance.root) == 1
+            assert instance.root[0].id == 1
+
+
+class TestBug3ConfigEnvVarName:
+    """
+    Bug 3: generated config.py docstring example says API_BASE_URL but
+    pydantic-settings maps field base_url to env var BASE_URL.  The wrong
+    name is silently ignored (extra='ignore') so the client defaults to
+    http://localhost.  The fix is to document the correct name BASE_URL.
+    """
+
+    def test_generated_config_documents_base_url_not_api_base_url(self, tmp_path):
+        """Generated config.py must document BASE_URL, not API_BASE_URL, in its env-var example."""
+        generator = _make_generator(tmp_path)
+        generator.generate()
+
+        config_content = (tmp_path / "config.py").read_text()
+
+        assert "API_BASE_URL" not in config_content, (
+            "config.py documents API_BASE_URL but pydantic-settings reads BASE_URL; the wrong name is silently ignored"
+        )
+        assert "BASE_URL" in config_content, "config.py should document BASE_URL as the environment variable name"
+
+    def test_generated_config_direct_instantiation_example_uses_base_url(self, tmp_path):
+        """The direct-instantiation example must use base_url=, not api_base_url=."""
+        generator = _make_generator(tmp_path)
+        generator.generate()
+
+        config_content = (tmp_path / "config.py").read_text()
+
+        assert "api_base_url=" not in config_content, (
+            "config.py uses api_base_url= in example but the field is base_url"
+        )
+        assert "base_url=" in config_content, "config.py direct-instantiation example should use base_url="


### PR DESCRIPTION
## Summary

Fixes two remaining bugs from [#248](https://github.com/phalt/clientele/issues/248) that were not addressed by PR #247.

Bug 1 (enum forward refs in `client.py`) was already resolved by PR #247 via `resolve_forward_refs_for_client()`.

### Bug 2 — Array responses emitted as type aliases, rejected by pydantic in `response_map`

Array response schemas were generated as plain type aliases:

```python
# before
UploadFaces200Response = list[FaceItem]
```

A `GenericAlias` (`list[...]`) is not a `type`, so pydantic raises a `ValidationError` when it appears in `response_map: dict[int, type[Any]]`:

```
pydantic_core.ValidationError: 1 validation error for RequestContext
response_map.200
  Input should be a type [type=is_type, input_value=list[FaceItem]]
```

**Fix:** emit a `pydantic.RootModel` subclass instead:

```python
# after
class UploadFaces200Response(pydantic.RootModel[list[FaceItem]]):
    pass
```

### Bug 3 — Generated `config.py` documents wrong environment variable name

The generated `config.py` docstring example showed:

```python
export API_BASE_URL="https://api.example.com"
config = Config(api_base_url=..., ...)
```

But `BaseConfig` declares the field as `base_url`, so pydantic-settings reads the env var `BASE_URL`. Because `SettingsConfigDict` has `extra="ignore"`, setting `API_BASE_URL` is silently ignored and the client always falls back to `http://localhost`.

**Fix:** updated `config_py.jinja2` to document `BASE_URL` and `base_url=` in the example.

## Test plan

- `TestBug2ArrayResponseRootModel` — asserts RootModel subclass is generated, passes `isinstance(cls, type)`, and is instantiable with a list
- `TestBug3ConfigEnvVarName` — asserts generated config documents `BASE_URL` and `base_url=`
- `test_complex_schemas.py` updated to assert RootModel output for existing array response tests