### PR TITLE
Fix HttpxHTTPBackend not resetting client after close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 2.2.2
+
+- Fix `HttpxHTTPBackend.close()`/`aclose()` not resetting the client reference — a closed-but-non-None client was returned on subsequent requests, causing `RuntimeError: Cannot send a request, as the client has been closed`.
+
 ## 2.2.1
 
 - Fix POST/PUT/PATCH endpoints without a request body generating a required `data: None` parameter — the `data` parameter is now omitted entirely when the endpoint has no request body.

--- a/clientele/http/httpx_backend.py
+++ b/clientele/http/httpx_backend.py
@@ -124,11 +124,13 @@ class HttpxHTTPBackend(backends.HTTPBackend):
         """Close the synchronous httpx client."""
         if self._sync_client is not None:
             self._sync_client.close()
+            self._sync_client = None
 
     async def aclose(self) -> None:
         """Asynchronously close the async httpx client."""
         if self._async_client is not None:
             await self._async_client.aclose()
+            self._async_client = None
 
     def handle_sync_stream(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clientele"
-version = "2.2.1"
+version = "2.2.2"
 description = "Clientele is a different way to build Python API Clients"
 authors = [{ name = "Paul Hallett", email = "paulandrewhallett@gmail.com" }]
 license = { text = "MIT" }

--- a/tests/api/test_api_client_singleton.py
+++ b/tests/api/test_api_client_singleton.py
@@ -91,6 +91,59 @@ async def test_aclose_method_works() -> None:
     assert client.config.http_backend is fake_backend
 
 
+def test_sync_request_works_after_close() -> None:
+    """Test that sync requests work after close() by rebuilding the client."""
+    client = APIClient(base_url=BASE_URL)
+    fake_backend = configure_client_for_testing(client)
+    fake_backend.queue_response(
+        path="/users/1",
+        response_obj=ResponseFactory.ok(data={"id": 1, "name": "Ada"}),
+    )
+    fake_backend.queue_response(
+        path="/users/1",
+        response_obj=ResponseFactory.ok(data={"id": 1, "name": "Ada"}),
+    )
+
+    @client.get("/users/{user_id}")
+    def get_user(result: User, user_id: int) -> User:
+        return result
+
+    user = get_user(1)
+    assert user.id == 1
+
+    client.close()
+
+    user = get_user(1)
+    assert user.id == 1
+
+
+@pytest.mark.asyncio
+async def test_async_request_works_after_aclose() -> None:
+    """Test that async requests work after aclose() by rebuilding the client."""
+    client = APIClient(base_url=BASE_URL)
+    fake_backend = configure_client_for_testing(client)
+    fake_backend.queue_response(
+        path="/users/1",
+        response_obj=ResponseFactory.ok(data={"id": 1, "name": "Ada"}),
+    )
+    fake_backend.queue_response(
+        path="/users/1",
+        response_obj=ResponseFactory.ok(data={"id": 1, "name": "Ada"}),
+    )
+
+    @client.get("/users/{user_id}")
+    async def get_user(result: User, user_id: int) -> User:
+        return result
+
+    user = await get_user(1)
+    assert user.id == 1
+
+    await client.aclose()
+
+    user = await get_user(1)
+    assert user.id == 1
+
+
 def test_can_reconfigure_with_base_url() -> None:
     """Test that base_url can be reconfigured."""
     client = APIClient(base_url="whatever")


### PR DESCRIPTION
## Summary

- `close()`/`aclose()` closed the underlying httpx client but did not reset the reference to `None`
- `build_client()`/`build_async_client()` then returned the closed instance on subsequent requests instead of creating a fresh one
- This caused `RuntimeError("Cannot send a request, as the client has been closed")` in long-running processes that reuse the client across event loops (e.g. reconcile loops)
- All other backends (requests, aiohttp, niquests) already reset to `None` — this aligns httpx with them

Ref: https://github.com/app-sre/qontract-reconcile/pull/5599

## Test plan

- [x] Added tests verifying sync/async requests succeed after `close()`/`aclose()`
- [x] All existing tests pass
- [x] ruff, mypy clean